### PR TITLE
Rename focusableId to propname: focusId

### DIFF
--- a/src/Navigation.jsx
+++ b/src/Navigation.jsx
@@ -203,7 +203,7 @@ class Navigation extends Component {
   }
 
   render() {
-    return <VerticalList ref={element => this.root = element} focusableId='navigation'>
+    return <VerticalList ref={element => this.root = element} focusId='navigation'>
       {this.props.children}
     </VerticalList>;
   }


### PR DESCRIPTION
The class property is named `focusableId` whereas the prop is called `focusId`. If I am understanding the code correctly.

With the current setup a property called `focusableId` is attached to the <span> element which throws warning in react.